### PR TITLE
Update pom.xml based on latest DSpace Parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,11 @@
     <packaging>jar</packaging>
  
     <properties>
-        <lib.maven-compiler-plugin.version>3.3</lib.maven-compiler-plugin.version>
+        <lib.maven-compiler-plugin.version>3.5.1</lib.maven-compiler-plugin.version>
         <lib.maven-dependency-plugin.version>2.10</lib.maven-dependency-plugin.version>
-        <lib.maven-enforcer-plugin.version>1.4</lib.maven-enforcer-plugin.version>
+        <lib.maven-enforcer-plugin.version>1.4.1</lib.maven-enforcer-plugin.version>
 
-        <min.java.version>1.6</min.java.version>
-        <min.maven.version>3.3.1</min.maven.version>
+        <min.java.version>1.7</min.java.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -85,7 +84,7 @@
         <dependency>
             <groupId>commons-jxpath</groupId>
             <artifactId>commons-jxpath</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
             <exclusions>
                 <exclusion>
                     <artifactId>ant-optional</artifactId>
@@ -218,14 +217,23 @@
                         <configuration>
                             <fail>true</fail>
                             <rules>
-                                <requireMavenVersion>
-                                    <version>[${min.maven.version},)</version>
-                                </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>[${min.java.version},)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
+                    </execution>
+                    <!-- Make sure that we do not have conflicting dependencies-->
+                    <execution>
+                            <id>enforce-versions</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <DependencyConvergence />
+                                </rules>
+                            </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Hi @cwilper.  Here's a POM update to this project to "sync" up with how the DSpace Parent POM is setup (on DSpace/DSpace master). 

Unfortunately, it shows a flaw in this module.  It doesn't pass dependency convergence checks (which the DSpace Parent POM also validates).  Here's the dependency error returned when running a `mvn install`:

```
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability the error(s) are [
Dependency convergence error for org.apache.excalibur.components:excalibur-sourceresolve:2.2.3 paths to dependency are:
+-org.dspace.dependencies.cocoon:dspace-cocoon-sitemap-impl:1.0.0
  +-org.apache.cocoon:cocoon-sitemap-api:1.0.0
    +-org.apache.cocoon:cocoon-pipeline-api:1.0.0
      +-org.apache.excalibur.components:excalibur-sourceresolve:2.2.3
and
+-org.dspace.dependencies.cocoon:dspace-cocoon-sitemap-impl:1.0.0
  +-org.apache.cocoon:cocoon-sitemap-api:1.0.0
    +-org.apache.cocoon:cocoon-pipeline-api:1.0.0
      +-org.apache.excalibur.components:excalibur-xmlutil:2.2.1
        +-org.apache.excalibur.components:excalibur-sourceresolve:2.2.1
and
+-org.dspace.dependencies.cocoon:dspace-cocoon-sitemap-impl:1.0.0
  +-org.apache.cocoon:cocoon-pipeline-impl:1.0.0
    +-org.apache.excalibur.components:excalibur-sourceresolve:2.2.3
,
Dependency convergence error for commons-jxpath:commons-jxpath:1.2 paths to dependency are:
+-org.dspace.dependencies.cocoon:dspace-cocoon-sitemap-impl:1.0.0
  +-org.apache.cocoon:cocoon-sitemap-impl:1.0.0
    +-commons-jxpath:commons-jxpath:1.2
and
+-org.dspace.dependencies.cocoon:dspace-cocoon-sitemap-impl:1.0.0
  +-org.apache.cocoon:cocoon-expression-language-impl:1.0.0
    +-commons-jxpath:commons-jxpath:1.2
and
+-org.dspace.dependencies.cocoon:dspace-cocoon-sitemap-impl:1.0.0
  +-commons-jxpath:commons-jxpath:1.3
,
Dependency convergence error for xml-apis:xml-apis:1.3.02 paths to dependency are:
+-org.dspace.dependencies.cocoon:dspace-cocoon-sitemap-impl:1.0.0
  +-org.apache.cocoon:cocoon-sitemap-impl:1.0.0
    +-xml-apis:xml-apis:1.3.02
and
+-org.dspace.dependencies.cocoon:dspace-cocoon-sitemap-impl:1.0.0
  +-org.apache.cocoon:cocoon-expression-language-impl:1.0.0
    +-org.apache.cocoon:cocoon-xml-util:1.0.0
      +-xml-apis:xml-apis:1.3.02
and
+-org.dspace.dependencies.cocoon:dspace-cocoon-sitemap-impl:1.0.0
  +-org.apache.cocoon:cocoon-pipeline-impl:1.0.0
    +-xml-apis:xml-apis:1.3.02
and
+-org.dspace.dependencies.cocoon:dspace-cocoon-sitemap-impl:1.0.0
  +-xml-apis:xml-apis:1.3.02
and
+-org.dspace.dependencies.cocoon:dspace-cocoon-sitemap-impl:1.0.0
  +-xerces:xercesImpl:2.8.1
    +-xml-apis:xml-apis:1.3.03
]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```

The root error seems to be that `cocoon-sitemap-api:1.0.0` actually pulls in two different versions of `excalibur-sourceresolve` (version 2.23 and 2.2.1).  This causes dependency convergence to fail when this `dspace-cocoon-sitemap-impl` is used with the latest DSpace/DSpace master code...resulting in a build failure.

Unfortunately, I don't have much time to look at this today, so I thought I'd log it in this PR which also shows the same error (since I enabled dependency convergence in this PR)
